### PR TITLE
all: switch to using a custom Reader interface

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -2,9 +2,15 @@ package config
 
 import (
 	"errors"
+	"io"
 
 	"github.com/hybridgroup/wasman/tollstation"
 )
+
+type Reader interface {
+	io.Reader
+	io.ReaderAt
+}
 
 const (
 	// MemoryPageSize is the unit of memory length in WebAssembly,

--- a/expr/expr_test.go
+++ b/expr/expr_test.go
@@ -38,10 +38,10 @@ func TestReadExpr(t *testing.T) {
 		} {
 			actual, err := expr.ReadExpression(bytes.NewReader(c.bytes))
 			if err != nil {
-				t.Fail()
+				t.Error(err)
 			}
 			if !reflect.DeepEqual(c.exp, actual) {
-				t.Fail()
+				t.Errorf("expected %v, got %v", c.exp, actual)
 			}
 		}
 	})

--- a/leb128decode/leb128.go
+++ b/leb128decode/leb128.go
@@ -1,9 +1,10 @@
 package leb128decode
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
+
+	"github.com/hybridgroup/wasman/utils"
 )
 
 const (
@@ -19,73 +20,73 @@ var (
 )
 
 // DecodeUint32 will decode a uint32 from io.Reader, returning it as the ret with the bytes length l which it read.
-func DecodeUint32(r *bytes.Reader) (ret uint32, bytesRead uint64, err error) {
+func DecodeUint32(r utils.Reader) (ret uint32, bytesRead uint64, err error) {
 	// Derived from https://github.com/golang/go/blob/aafad20b617ee63d58fcd4f6e0d98fe27760678c/src/encoding/binary/varint.go
 	// with the modification on the overflow handling tailored for 32-bits.
 	var s uint32
-	var b byte
+	var b [1]byte
 	for i := 0; i < maxVarintLen32; i++ {
-		b, err = r.ReadByte()
+		_, err = r.Read(b[:])
 		if err != nil {
 			return 0, 0, err
 		}
-		if b < 0x80 {
+		if b[0] < 0x80 {
 			// Unused bits must be all zero.
-			if i == maxVarintLen32-1 && (b&0xf0) > 0 {
+			if i == maxVarintLen32-1 && (b[0]&0xf0) > 0 {
 				return 0, 0, errOverflow32
 			}
-			return ret | uint32(b)<<s, uint64(i) + 1, nil
+			return ret | uint32(b[0])<<s, uint64(i) + 1, nil
 		}
-		ret |= (uint32(b) & 0x7f) << s
+		ret |= (uint32(b[0]) & 0x7f) << s
 		s += 7
 	}
 	return 0, 0, errOverflow32
 }
 
 // DecodeUint64 will decode a uint64 from io.Reader, returning it as the ret with the bytes length l which it read.
-func DecodeUint64(r *bytes.Reader) (ret uint64, bytesRead uint64, err error) {
+func DecodeUint64(r utils.Reader) (ret uint64, bytesRead uint64, err error) {
 	// Derived from https://github.com/golang/go/blob/aafad20b617ee63d58fcd4f6e0d98fe27760678c/src/encoding/binary/varint.go
 	var s uint64
-	var b byte
+	var b [1]byte
 	for i := 0; i < maxVarintLen64; i++ {
-		b, err = r.ReadByte()
+		_, err = r.Read(b[:])
 		if err != nil {
 			return 0, 0, err
 		}
-		if b < 0x80 {
+		if b[0] < 0x80 {
 			// Unused bits (non first bit) must all be zero.
-			if i == maxVarintLen64-1 && b > 1 {
+			if i == maxVarintLen64-1 && b[0] > 1 {
 				return 0, 0, errOverflow64
 			}
-			return ret | uint64(b)<<s, uint64(i) + 1, nil
+			return ret | uint64(b[0])<<s, uint64(i) + 1, nil
 		}
-		ret |= (uint64(b) & 0x7f) << s
+		ret |= (uint64(b[0]) & 0x7f) << s
 		s += 7
 	}
 	return 0, 0, errOverflow64
 }
 
 // DecodeInt32 will decode a int32 from io.Reader, returning it as the ret with the bytes length l which it read.
-func DecodeInt32(r *bytes.Reader) (ret int32, bytesRead uint64, err error) {
+func DecodeInt32(r utils.Reader) (ret int32, bytesRead uint64, err error) {
 	var shift int
-	var b byte
+	var b [1]byte
 	for {
-		b, err = r.ReadByte()
+		_, err = r.Read(b[:])
 		if err != nil {
 			return 0, 0, fmt.Errorf("readByte failed: %w", err)
 		}
-		ret |= (int32(b) & 0x7f) << shift
+		ret |= (int32(b[0]) & 0x7f) << shift
 		shift += 7
 		bytesRead++
-		if b&0x80 == 0 {
-			if shift < 32 && (b&0x40) != 0 {
+		if b[0]&0x80 == 0 {
+			if shift < 32 && (b[0]&0x40) != 0 {
 				ret |= ^0 << shift
 			}
 			// Over flow checks.
 			// fixme: can be optimized.
 			if bytesRead > 5 {
 				return 0, 0, errOverflow32
-			} else if unused := b & 0b00110000; bytesRead == 5 && ret < 0 && unused != 0b00110000 {
+			} else if unused := b[0] & 0b00110000; bytesRead == 5 && ret < 0 && unused != 0b00110000 {
 				return 0, 0, errOverflow32
 			} else if bytesRead == 5 && ret >= 0 && unused != 0x00 {
 				return 0, 0, errOverflow32
@@ -96,7 +97,7 @@ func DecodeInt32(r *bytes.Reader) (ret int32, bytesRead uint64, err error) {
 }
 
 // DecodeInt33AsInt64 will decode a int33 from io.Reader, returning it as the int64 ret with the bytes length l which it read.
-func DecodeInt33AsInt64(r *bytes.Reader) (ret int64, bytesRead uint64, err error) {
+func DecodeInt33AsInt64(r utils.Reader) (ret int64, bytesRead uint64, err error) {
 	const (
 		int33Mask  int64 = 1 << 7
 		int33Mask2       = ^int33Mask
@@ -107,13 +108,13 @@ func DecodeInt33AsInt64(r *bytes.Reader) (ret int64, bytesRead uint64, err error
 	)
 	var shift int
 	var b int64
-	var rb byte
+	var rb [1]byte
 	for shift < 35 {
-		rb, err = r.ReadByte()
+		_, err = r.Read(rb[:])
 		if err != nil {
 			return 0, 0, fmt.Errorf("readByte failed: %w", err)
 		}
-		b = int64(rb)
+		b = int64(rb[0])
 		ret |= (b & int33Mask2) << shift
 		shift += 7
 		bytesRead++
@@ -145,30 +146,30 @@ func DecodeInt33AsInt64(r *bytes.Reader) (ret int64, bytesRead uint64, err error
 }
 
 // DecodeInt64 will decode a int64 from io.Reader, returning it as the ret with the bytes length l which it read.
-func DecodeInt64(r *bytes.Reader) (ret int64, bytesRead uint64, err error) {
+func DecodeInt64(r utils.Reader) (ret int64, bytesRead uint64, err error) {
 	const (
 		int64Mask3 = 1 << 6
 		int64Mask4 = ^0
 	)
 	var shift int
-	var b byte
+	var b [1]byte
 	for {
-		b, err = r.ReadByte()
+		_, err = r.Read(b[:])
 		if err != nil {
 			return 0, 0, fmt.Errorf("readByte failed: %w", err)
 		}
-		ret |= (int64(b) & 0x7f) << shift
+		ret |= (int64(b[0]) & 0x7f) << shift
 		shift += 7
 		bytesRead++
-		if b&0x80 == 0 {
-			if shift < 64 && (b&int64Mask3) == int64Mask3 {
+		if b[0]&0x80 == 0 {
+			if shift < 64 && (b[0]&int64Mask3) == int64Mask3 {
 				ret |= int64Mask4 << shift
 			}
 			// Over flow checks.
 			// fixme: can be optimized.
 			if bytesRead > 10 {
 				return 0, 0, errOverflow64
-			} else if unused := b & 0b00111110; bytesRead == 10 && ret < 0 && unused != 0b00111110 {
+			} else if unused := b[0] & 0b00111110; bytesRead == 10 && ret < 0 && unused != 0b00111110 {
 				return 0, 0, errOverflow64
 			} else if bytesRead == 10 && ret >= 0 && unused != 0x00 {
 				return 0, 0, errOverflow64

--- a/module.go
+++ b/module.go
@@ -2,10 +2,9 @@ package wasman
 
 import (
 	"bytes"
-	"io"
-	"io/ioutil"
 
 	"github.com/hybridgroup/wasman/config"
+	"github.com/hybridgroup/wasman/utils"
 	"github.com/hybridgroup/wasman/wasm"
 )
 
@@ -13,13 +12,8 @@ import (
 type Module = wasm.Module
 
 // NewModule is a wrapper to the wasm.NewModule
-func NewModule(config config.ModuleConfig, r io.Reader) (*Module, error) {
-	b, err := ioutil.ReadAll(r)
-	if err != nil {
-		return nil, err
-	}
-
-	return wasm.NewModule(config, bytes.NewReader(b))
+func NewModule(config config.ModuleConfig, r utils.Reader) (*Module, error) {
+	return wasm.NewModule(config, r)
 }
 
 // NewModuleFromBytes is a wrapper to the wasm.NewModule that avoids having to

--- a/segments/code.go
+++ b/segments/code.go
@@ -1,12 +1,12 @@
 package segments
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 
 	"github.com/hybridgroup/wasman/expr"
 	"github.com/hybridgroup/wasman/leb128decode"
+	"github.com/hybridgroup/wasman/utils"
 )
 
 // CodeSegment is one unit in the wasman.Module's CodeSection
@@ -16,7 +16,7 @@ type CodeSegment struct {
 }
 
 // ReadCodeSegment reads one CodeSegment from the io.Reader
-func ReadCodeSegment(r *bytes.Reader) (*CodeSegment, error) {
+func ReadCodeSegment(r utils.Reader) (*CodeSegment, error) {
 	ss, _, err := leb128decode.DecodeUint32(r)
 	if err != nil {
 		return nil, fmt.Errorf("get the size of code segment: %w", err)
@@ -34,6 +34,7 @@ func ReadCodeSegment(r *bytes.Reader) (*CodeSegment, error) {
 
 	var numLocals uint32
 	var n uint32
+	var b [1]byte
 	for i := uint32(0); i < ls; i++ {
 		n, bytesRead, err = leb128decode.DecodeUint32(r)
 		remaining -= int64(bytesRead) + 1 // +1 for the subsequent ReadByte
@@ -44,7 +45,7 @@ func ReadCodeSegment(r *bytes.Reader) (*CodeSegment, error) {
 		}
 		numLocals += n
 
-		if _, err := r.ReadByte(); err != nil {
+		if _, err := r.Read(b[:]); err != nil {
 			return nil, fmt.Errorf("read type of local") // TODO: save read localType
 		}
 	}

--- a/segments/data.go
+++ b/segments/data.go
@@ -1,12 +1,12 @@
 package segments
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 
 	"github.com/hybridgroup/wasman/expr"
 	"github.com/hybridgroup/wasman/leb128decode"
+	"github.com/hybridgroup/wasman/utils"
 )
 
 // DataSegment is one unit of the wasman.Module's DataSection, initializing
@@ -20,7 +20,7 @@ type DataSegment struct {
 }
 
 // ReadDataSegment reads one DataSegment from the io.Reader
-func ReadDataSegment(r *bytes.Reader) (*DataSegment, error) {
+func ReadDataSegment(r utils.Reader) (*DataSegment, error) {
 	d, _, err := leb128decode.DecodeUint32(r)
 	if err != nil {
 		return nil, fmt.Errorf("read memory index: %w", err)

--- a/segments/data_test.go
+++ b/segments/data_test.go
@@ -39,10 +39,10 @@ func TestDataSegment(t *testing.T) {
 		t.Run(utils.IntToString(i), func(t *testing.T) {
 			actual, err := segments.ReadDataSegment(bytes.NewReader(c.bytes))
 			if err != nil {
-				t.Fail()
+				t.Error(err)
 			}
 			if !reflect.DeepEqual(c.exp, actual) {
-				t.Fail()
+				t.Errorf("expected %v, got %v", c.exp, actual)
 			}
 		})
 	}

--- a/segments/elem.go
+++ b/segments/elem.go
@@ -1,11 +1,11 @@
 package segments
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/hybridgroup/wasman/expr"
 	"github.com/hybridgroup/wasman/leb128decode"
+	"github.com/hybridgroup/wasman/utils"
 )
 
 // ElemSegment is one unit of the wasm.Module's ElementsSection, initializing
@@ -19,7 +19,7 @@ type ElemSegment struct {
 }
 
 // ReadElemSegment reads one ElemSegment from the io.Reader
-func ReadElemSegment(r *bytes.Reader) (*ElemSegment, error) {
+func ReadElemSegment(r utils.Reader) (*ElemSegment, error) {
 	ti, _, err := leb128decode.DecodeUint32(r)
 	if err != nil {
 		return nil, fmt.Errorf("get table index: %w", err)

--- a/segments/export.go
+++ b/segments/export.go
@@ -1,12 +1,12 @@
 package segments
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 
 	"github.com/hybridgroup/wasman/leb128decode"
 	"github.com/hybridgroup/wasman/types"
+	"github.com/hybridgroup/wasman/utils"
 )
 
 // ExportDesc means export descriptions, which describe an export in one wasman.Module
@@ -16,7 +16,7 @@ type ExportDesc struct {
 }
 
 // ReadExportDesc reads one ExportDesc from the io.Reader
-func ReadExportDesc(r *bytes.Reader) (*ExportDesc, error) {
+func ReadExportDesc(r utils.Reader) (*ExportDesc, error) {
 	b := make([]byte, 1)
 	if _, err := io.ReadFull(r, b); err != nil {
 		return nil, fmt.Errorf("read value kind: %w", err)
@@ -45,7 +45,7 @@ type ExportSegment struct {
 }
 
 // ReadExportSegment reads one ExportSegment from the io.Reader
-func ReadExportSegment(r *bytes.Reader) (*ExportSegment, error) {
+func ReadExportSegment(r utils.Reader) (*ExportSegment, error) {
 	name, err := types.ReadNameValue(r)
 	if err != nil {
 		return nil, fmt.Errorf("read name of export module: %w", err)

--- a/segments/global.go
+++ b/segments/global.go
@@ -1,11 +1,11 @@
 package segments
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/hybridgroup/wasman/expr"
 	"github.com/hybridgroup/wasman/types"
+	"github.com/hybridgroup/wasman/utils"
 )
 
 // GlobalSegment is one unit of the wasm.Module's GlobalSection
@@ -15,7 +15,7 @@ type GlobalSegment struct {
 }
 
 // ReadGlobalSegment reads one GlobalSegment from the io.Reader
-func ReadGlobalSegment(r *bytes.Reader) (*GlobalSegment, error) {
+func ReadGlobalSegment(r utils.Reader) (*GlobalSegment, error) {
 	gt, err := types.ReadGlobalType(r)
 	if err != nil {
 		return nil, fmt.Errorf("read global type: %w", err)

--- a/segments/import.go
+++ b/segments/import.go
@@ -1,12 +1,12 @@
 package segments
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 
 	"github.com/hybridgroup/wasman/leb128decode"
 	"github.com/hybridgroup/wasman/types"
+	"github.com/hybridgroup/wasman/utils"
 )
 
 // ImportDesc means import descriptions, which describe an import in one wasman.Module
@@ -20,7 +20,7 @@ type ImportDesc struct {
 }
 
 // ReadImportDesc reads one ImportDesc from the io.Reader
-func ReadImportDesc(r *bytes.Reader) (*ImportDesc, error) {
+func ReadImportDesc(r utils.Reader) (*ImportDesc, error) {
 	b := make([]byte, 1)
 	if _, err := io.ReadFull(r, b); err != nil {
 		return nil, fmt.Errorf("read value kind: %w", err)
@@ -77,7 +77,7 @@ type ImportSegment struct {
 }
 
 // ReadImportSegment reads one ImportSegment from the io.Reader
-func ReadImportSegment(r *bytes.Reader) (*ImportSegment, error) {
+func ReadImportSegment(r utils.Reader) (*ImportSegment, error) {
 	mn, err := types.ReadNameValue(r)
 	if err != nil {
 		return nil, fmt.Errorf("read name of imported module: %w", err)

--- a/types/func.go
+++ b/types/func.go
@@ -1,11 +1,11 @@
 package types
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 
 	"github.com/hybridgroup/wasman/leb128decode"
+	"github.com/hybridgroup/wasman/utils"
 )
 
 // FuncType classify the signature of functions, mapping a vector of parameters to a vector of results, written as follows.
@@ -15,7 +15,7 @@ type FuncType struct {
 }
 
 // ReadFuncType will read a types.ReadFuncType from the io.Reader
-func ReadFuncType(r *bytes.Reader) (*FuncType, error) {
+func ReadFuncType(r utils.Reader) (*FuncType, error) {
 	b := make([]byte, 1)
 	if _, err := io.ReadFull(r, b); err != nil {
 		return nil, fmt.Errorf("read leading byte: %w", err)

--- a/types/limits.go
+++ b/types/limits.go
@@ -1,11 +1,11 @@
 package types
 
 import (
-	"bytes"
 	"fmt"
 	"io"
 
 	"github.com/hybridgroup/wasman/leb128decode"
+	"github.com/hybridgroup/wasman/utils"
 )
 
 // Limits classify the size range of resizeable storage associated with memory types and table types
@@ -16,7 +16,7 @@ type Limits struct {
 }
 
 // ReadLimits will read a types.Limits from the io.Reader
-func ReadLimits(r *bytes.Reader) (*Limits, error) {
+func ReadLimits(r utils.Reader) (*Limits, error) {
 	b := make([]byte, 1)
 	_, err := io.ReadFull(r, b)
 	if err != nil {

--- a/types/memory.go
+++ b/types/memory.go
@@ -1,12 +1,12 @@
 package types
 
-import "bytes"
+import "github.com/hybridgroup/wasman/utils"
 
 // MemoryType classify linear memories and their size range.
 // https://www.w3.org/TR/wasm-core-1/#memory-types%E2%91%A0
 type MemoryType = Limits
 
 // ReadMemoryType will read a types.MemoryType from the io.Reader
-func ReadMemoryType(r *bytes.Reader) (*MemoryType, error) {
+func ReadMemoryType(r utils.Reader) (*MemoryType, error) {
 	return ReadLimits(r)
 }

--- a/types/table.go
+++ b/types/table.go
@@ -1,9 +1,10 @@
 package types
 
 import (
-	"bytes"
 	"fmt"
 	"io"
+
+	"github.com/hybridgroup/wasman/utils"
 )
 
 // TableType classify tables over elements of element types within a size range.
@@ -14,7 +15,7 @@ type TableType struct {
 }
 
 // ReadTableType will read a types.TableType from the io.Reader
-func ReadTableType(r *bytes.Reader) (*TableType, error) {
+func ReadTableType(r utils.Reader) (*TableType, error) {
 	b := make([]byte, 1)
 	if _, err := io.ReadFull(r, b); err != nil {
 		return nil, fmt.Errorf("read leading byte: %w", err)

--- a/types/value.go
+++ b/types/value.go
@@ -1,12 +1,12 @@
 package types
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
 
 	"github.com/hybridgroup/wasman/leb128decode"
+	"github.com/hybridgroup/wasman/utils"
 )
 
 // ErrInvalidTypeByte means the type byte mismatches the one from wasm binary
@@ -69,7 +69,7 @@ func ReadValueTypes(r io.Reader, num uint32) ([]ValueType, error) {
 }
 
 // ReadNameValue will read a name string from the io.Reader
-func ReadNameValue(r *bytes.Reader) (string, error) {
+func ReadNameValue(r utils.Reader) (string, error) {
 	vs, _, err := leb128decode.DecodeUint32(r)
 	if err != nil {
 		return "", fmt.Errorf("read size of name: %w", err)

--- a/utils/reader.go
+++ b/utils/reader.go
@@ -1,0 +1,9 @@
+package utils
+
+import "io"
+
+type Reader interface {
+	io.Reader
+	io.ReaderAt
+	io.Seeker
+}

--- a/wasm/instance_init.go
+++ b/wasm/instance_init.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hybridgroup/wasman/leb128decode"
 	"github.com/hybridgroup/wasman/segments"
 	"github.com/hybridgroup/wasman/types"
+	"github.com/hybridgroup/wasman/utils"
 )
 
 // buildIndexSpaces build index spaces of the module with the given external modules
@@ -274,7 +275,7 @@ func (ins *Instance) buildTableIndexSpace() error {
 
 type blockType = types.FuncType
 
-func (ins *Instance) readBlockType(r *bytes.Reader) (*blockType, uint64, error) {
+func (ins *Instance) readBlockType(r utils.Reader) (*blockType, uint64, error) {
 	raw, l, err := leb128decode.DecodeInt33AsInt64(r)
 	if err != nil {
 		return nil, 0, fmt.Errorf("decode int33: %w", err)

--- a/wasm/module.go
+++ b/wasm/module.go
@@ -7,6 +7,7 @@ import (
 	"io"
 
 	"github.com/hybridgroup/wasman/config"
+	"github.com/hybridgroup/wasman/utils"
 
 	"github.com/hybridgroup/wasman/segments"
 	"github.com/hybridgroup/wasman/types"
@@ -54,7 +55,7 @@ type IndexSpace struct {
 }
 
 // NewModule reads bytes from the io.Reader and read all sections, finally return a wasman.Module entity if no error
-func NewModule(config config.ModuleConfig, r *bytes.Reader) (*Module, error) {
+func NewModule(config config.ModuleConfig, r utils.Reader) (*Module, error) {
 	// magic number
 	buf := make([]byte, 4)
 	if n, err := io.ReadFull(r, buf); err != nil || n != 4 || !bytes.Equal(buf, magic) {

--- a/wasm/section.go
+++ b/wasm/section.go
@@ -1,7 +1,6 @@
 package wasm
 
 import (
-	"bytes"
 	"errors"
 	"fmt"
 	"io"
@@ -9,6 +8,7 @@ import (
 	"github.com/hybridgroup/wasman/leb128decode"
 	"github.com/hybridgroup/wasman/segments"
 	"github.com/hybridgroup/wasman/types"
+	"github.com/hybridgroup/wasman/utils"
 )
 
 type sectionID byte
@@ -29,7 +29,7 @@ const (
 	sectionIDDataCount sectionID = 12
 )
 
-func (m *Module) readSections(r *bytes.Reader) error {
+func (m *Module) readSections(r utils.Reader) error {
 	for {
 		if err := m.readSection(r); errors.Is(err, io.EOF) {
 			return nil
@@ -39,7 +39,7 @@ func (m *Module) readSections(r *bytes.Reader) error {
 	}
 }
 
-func (m *Module) readSection(r *bytes.Reader) error {
+func (m *Module) readSection(r utils.Reader) error {
 	b := make([]byte, 1)
 	if _, err := io.ReadFull(r, b); err != nil {
 		return fmt.Errorf("read section id: %w", err)
@@ -89,7 +89,7 @@ func (m *Module) readSection(r *bytes.Reader) error {
 	return nil
 }
 
-func (m *Module) readSectionTypes(r *bytes.Reader) error {
+func (m *Module) readSectionTypes(r utils.Reader) error {
 	vs, _, err := leb128decode.DecodeUint32(r)
 	if err != nil {
 		return fmt.Errorf("get size of vector: %w", err)
@@ -106,7 +106,7 @@ func (m *Module) readSectionTypes(r *bytes.Reader) error {
 	return nil
 }
 
-func (m *Module) readSectionImports(r *bytes.Reader) error {
+func (m *Module) readSectionImports(r utils.Reader) error {
 	vs, _, err := leb128decode.DecodeUint32(r)
 	if err != nil {
 		return fmt.Errorf("get size of vector: %w", err)
@@ -123,7 +123,7 @@ func (m *Module) readSectionImports(r *bytes.Reader) error {
 	return nil
 }
 
-func (m *Module) readSectionFunctions(r *bytes.Reader) error {
+func (m *Module) readSectionFunctions(r utils.Reader) error {
 	vs, _, err := leb128decode.DecodeUint32(r)
 	if err != nil {
 		return fmt.Errorf("get size of vector: %w", err)
@@ -140,7 +140,7 @@ func (m *Module) readSectionFunctions(r *bytes.Reader) error {
 	return nil
 }
 
-func (m *Module) readSectionTables(r *bytes.Reader) error {
+func (m *Module) readSectionTables(r utils.Reader) error {
 	vs, _, err := leb128decode.DecodeUint32(r)
 	if err != nil {
 		return fmt.Errorf("get size of vector: %w", err)
@@ -157,7 +157,7 @@ func (m *Module) readSectionTables(r *bytes.Reader) error {
 	return nil
 }
 
-func (m *Module) readSectionMemories(r *bytes.Reader) error {
+func (m *Module) readSectionMemories(r utils.Reader) error {
 	vs, _, err := leb128decode.DecodeUint32(r)
 	if err != nil {
 		return fmt.Errorf("get size of vector: %w", err)
@@ -174,7 +174,7 @@ func (m *Module) readSectionMemories(r *bytes.Reader) error {
 	return nil
 }
 
-func (m *Module) readSectionGlobals(r *bytes.Reader) error {
+func (m *Module) readSectionGlobals(r utils.Reader) error {
 	vs, _, err := leb128decode.DecodeUint32(r)
 	if err != nil {
 		return fmt.Errorf("get size of vector: %w", err)
@@ -191,7 +191,7 @@ func (m *Module) readSectionGlobals(r *bytes.Reader) error {
 	return nil
 }
 
-func (m *Module) readSectionExports(r *bytes.Reader) error {
+func (m *Module) readSectionExports(r utils.Reader) error {
 	vs, _, err := leb128decode.DecodeUint32(r)
 	if err != nil {
 		return fmt.Errorf("get size of vector: %w", err)
@@ -210,7 +210,7 @@ func (m *Module) readSectionExports(r *bytes.Reader) error {
 	return nil
 }
 
-func (m *Module) readSectionStart(r *bytes.Reader) error {
+func (m *Module) readSectionStart(r utils.Reader) error {
 	var err error
 	m.StartSection = make([]uint32, 1)
 	m.StartSection[0], _, err = leb128decode.DecodeUint32(r)
@@ -221,7 +221,7 @@ func (m *Module) readSectionStart(r *bytes.Reader) error {
 	return nil
 }
 
-func (m *Module) readSectionElement(r *bytes.Reader) error {
+func (m *Module) readSectionElement(r utils.Reader) error {
 	vs, _, err := leb128decode.DecodeUint32(r)
 	if err != nil {
 		return fmt.Errorf("get size of vector: %w", err)
@@ -238,7 +238,7 @@ func (m *Module) readSectionElement(r *bytes.Reader) error {
 	return nil
 }
 
-func (m *Module) readSectionCodes(r *bytes.Reader) error {
+func (m *Module) readSectionCodes(r utils.Reader) error {
 	vs, _, err := leb128decode.DecodeUint32(r)
 	if err != nil {
 		return fmt.Errorf("get size of vector: %w", err)
@@ -255,7 +255,7 @@ func (m *Module) readSectionCodes(r *bytes.Reader) error {
 	return nil
 }
 
-func (m *Module) readSectionData(r *bytes.Reader) error {
+func (m *Module) readSectionData(r utils.Reader) error {
 	vs, _, err := leb128decode.DecodeUint32(r)
 	if err != nil {
 		return fmt.Errorf("get size of vector: %w", err)
@@ -276,7 +276,7 @@ func (m *Module) readSectionData(r *bytes.Reader) error {
 	return nil
 }
 
-func (m *Module) readSectionDataCount(r *bytes.Reader) error {
+func (m *Module) readSectionDataCount(r utils.Reader) error {
 	vs, _, err := leb128decode.DecodeUint32(r)
 	if err != nil {
 		return fmt.Errorf("get size of vector: %w", err)


### PR DESCRIPTION
This PR switches to using a custom Reader interface instead of bytes.Reader to avoid extra copying of data when loading a WASM file.